### PR TITLE
Fix dict mapping on package_data to be list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
     install_requires=dependencies,
     include_package_data=True,
     package_data={
-        'chainerrl_visualizer': {
+        'chainerrl_visualizer': [
             'templates/*',
             'static/**/*',
-        }
+        ]
     },
     author='sykwer',
     author_email='sykwer@gmail.com',


### PR DESCRIPTION
Due to the following fix, package_data's dict must to be list.
https://github.com/pypa/setuptools/commit/8f848bd777278fc8dcb42dc45751cd8b95ec2a02
https://github.com/pypa/setuptools/issues/1459